### PR TITLE
Removed nanoid dependency - simple id generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
         "@angular/router": "7.0.0",
         "@ngxs/store": "3.2.0",
         "core-js": "2.5.4",
-        "nanoid": "1.3.3",
         "rxjs": "6.0.0",
         "zone.js": "0.8.26"
     },
@@ -66,7 +65,6 @@
         "@angular/language-service": "7.0.0",
         "@types/jasmine": "2.8.6",
         "@types/jasminewd2": "2.0.3",
-        "@types/nanoid": "1.2.0",
         "@types/node": "8.9.4",
         "@types/semver": "5.5.0",
         "@types/yargs": "12.0.1",

--- a/src/lib/core/decorators/receiver.ts
+++ b/src/lib/core/decorators/receiver.ts
@@ -1,6 +1,4 @@
-const generate = require('nanoid/generate');
-
-import { ensureStoreMetadata, ReceiverMetaData, RECEIVER_META_KEY } from '../internal/internals';
+import { ensureStoreMetadata, generateRandomString, RECEIVER_META_KEY, ReceiverMetaData } from '../internal/internals';
 
 /**
  * Decorates a method with a receiver information
@@ -29,7 +27,7 @@ export function Receiver(options?: Partial<ReceiverMetaData>): MethodDecorator {
         }
 
         const payload = options && options.payload;
-        const actionId: string = generate('1234567890abcdef', 10);
+        const actionId: string = generateRandomString();
 
         let type: string = null!;
         if (action) {

--- a/src/lib/core/internal/internals.ts
+++ b/src/lib/core/internal/internals.ts
@@ -1,5 +1,4 @@
 import { Type } from '@angular/core';
-
 import { Observable } from 'rxjs';
 
 /**
@@ -106,4 +105,13 @@ export function ensureStoreMetadata(target: Function): any {
  */
 function getStoreMetadata(target: Function): any | undefined {
     return target[META_KEY];
+}
+
+/**
+ * Returns a random string consisting of digits
+ *
+ * @returns - random string
+ */
+export function generateRandomString(): string {
+    return crypto.getRandomValues(new Uint8Array(5)).join('');
 }

--- a/src/lib/core/internal/internals.ts
+++ b/src/lib/core/internal/internals.ts
@@ -108,10 +108,10 @@ function getStoreMetadata(target: Function): any | undefined {
 }
 
 /**
- * Returns a random string consisting of digits
+ * Returns a random string
  *
  * @returns - random string
  */
 export function generateRandomString(): string {
-    return crypto.getRandomValues(new Uint8Array(5)).join('');
+    return (Math.random() * Date.now()).toString(36).slice(0,8);
 }

--- a/src/package.json
+++ b/src/package.json
@@ -19,8 +19,7 @@
     "sideEffects": true,
     "peerDependencies": {
         "@angular/core": "^7.0.0",
-        "@ngxs/store": "^0.0.0",
-        "nanoid": "^0.0.0"
+        "@ngxs/store": "^0.0.0"
     },
     "ngPackage": {
         "lib": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,13 +278,6 @@
   dependencies:
     "@types/jasmine" "*"
 
-"@types/nanoid@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@types/nanoid/-/nanoid-1.2.0.tgz#c0141cfec5b4818016355389b0bd539097d872ff"
-  integrity sha512-3/PFKYBTN3xDsABhbXS007PVhdKvDMkaG6nE83/dIaC2LOLhW6fPt9bOR6UdlRGLk4vy6fEvC9MjKy4CLFAjuQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*":
   version "10.11.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.2.tgz#59508b88ce90fe2742f7b8414c6f5db3e359570d"
@@ -4977,11 +4970,6 @@ nan@^2.10.0, nan@^2.9.2:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.0.tgz#574e360e4d954ab16966ec102c0c049fd961a099"
   integrity sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==
-
-nanoid@1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-1.3.3.tgz#23d4130cb3dcb455c742cbf281163d52f0cd51b0"
-  integrity sha512-07OUEbP7fMX/tFLP3oIa3yTt+sUfDQf99JULSKc/ZNERIVG8T87S+Kt9iu6N4efVzmeMvlXjVUUQcEXKEm0OCQ==
 
 nanomatch@^1.2.9:
   version "1.2.13"


### PR DESCRIPTION
Very basic generator to generate a unique Id. Uses [crypto.getRandomValues](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues).
[CanIUse](https://caniuse.com/#feat=getrandomvalues) shows that all major browsers implement this function.

#45 