### PR TITLE
feat: require more granular payload type

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ export class CounterComponent {
 
     // Use in components to emit asynchronously payload
     @Emitter(CounterState.increment)
-    public increment: Emittable<void>;
+    public increment: Emittable;
 
     @Emitter(CounterState.decrement)
-    public decrement: Emittable<void>;
+    public decrement: Emittable;
 }
-```
+``` 
 
 Alternatively you can use `EmitterService` instead of decorating properties:
 
@@ -175,6 +175,8 @@ export class CounterState {
 ```
 
 ## Payload type safety 
+`Emittable` and `EmitterAction` are generics which allow you to type the payload, which is `void` (alias not present) by default.
+For example, `Emittable` is the same as `Emittable<void>`. Also it's possible to type it like `Emittable<number>` or `Emittable<any>` (if you want it to accept all possible values).
 
 ```typescript
 import { Component } from '@angular/core';
@@ -200,7 +202,7 @@ export class AppComponent {
     private update: Emittable<CustomCounter>;
 
     public update(): void {
-        this.update.emit(undefined as any);
+        this.update.emit({ value: 5 });
     }
 }
 ```
@@ -491,13 +493,13 @@ import { CounterState } from './counter.state';
 })
 export class AppComponent {
     @Emitter(CounterState.increment)
-    private increment: Emittable<void>;
+    private increment: Emittable;
 
     @Emitter(CounterState.decrement)
-    private decrement: Emittable<void>;
+    private decrement: Emittable;
 
     @Emitter(CounterState.throwError)
-    private throwError: Emittable<void>;
+    private throwError: Emittable;
 
     constructor(actions$: Actions) {
         actions$.pipe(

--- a/emitter/src/lib/core/actions/actions.ts
+++ b/emitter/src/lib/core/actions/actions.ts
@@ -1,7 +1,7 @@
 /**
  * This class is used as a default action when the user doesn't pass any custom action as an argument
  */
-export class EmitterAction<T = any> {
+export class EmitterAction<T = void> {
   /**
    * Action type
    */
@@ -12,5 +12,5 @@ export class EmitterAction<T = any> {
    *
    * @param payload - Data to dispatch
    */
-  constructor(public payload?: T) {}
+  constructor(public payload: T) {}
 }

--- a/emitter/src/lib/core/internal/internals.ts
+++ b/emitter/src/lib/core/internal/internals.ts
@@ -39,9 +39,9 @@ export interface ReceiverMetaData<T extends Function = any> {
  * @property emit - Function that dispatches payload under the hood
  * @property emitMany - Function that makes multiple dispatching under the hood
  */
-export interface Emittable<T = any, U = any> {
-  emit(payload?: T): Observable<U>;
-  emitMany(payloads?: T[]): Observable<U>;
+export interface Emittable<T = void, U = any> {
+  emit(payload: T): Observable<U>;
+  emitMany(payloads: T[]): Observable<U>;
 }
 
 /**
@@ -64,7 +64,7 @@ export interface ActionContext {
  * @property payload - Dispatched data
  * @property error - Error that has been throwed or undefined
  */
-export interface OfEmittableActionContext<T = any> {
+export interface OfEmittableActionContext<T = void> {
   type: string;
   payload: T;
   error?: Error;

--- a/emitter/src/lib/core/services/emit-store.service.ts
+++ b/emitter/src/lib/core/services/emit-store.service.ts
@@ -19,7 +19,7 @@ export class EmitStore extends Store {
    * @param receiver - Reference to the static function from the store
    * @returns - A plain object with an `emit` function for calling emitter
    */
-  public emitter<T = any, U = any>(receiver: Function): Emittable<T, U> {
+  public emitter<T = void, U = any>(receiver: Function): Emittable<T, U> {
     const metadata: ReceiverMetaData = receiver[RECEIVER_META_KEY];
 
     if (is.falsy(metadata)) {
@@ -27,8 +27,8 @@ export class EmitStore extends Store {
     }
 
     return {
-      emit: (payload?: T) => this.dispatchSingle<T, U>(metadata, payload),
-      emitMany: (payloads?: T[]) => this.dispatchMany<T, U>(metadata, payloads)
+      emit: (payload: T) => this.dispatchSingle<T, U>(metadata, payload),
+      emitMany: (payloads: T[]) => this.dispatchMany<T, U>(metadata, payloads)
     };
   }
 
@@ -37,7 +37,7 @@ export class EmitStore extends Store {
    * @param payload - Data to dispatch
    * @returns - An observable that emits events after dispatch
    */
-  private dispatchSingle<T, U>(metadata: ReceiverMetaData, payload?: T): Observable<U> {
+  private dispatchSingle<T, U>(metadata: ReceiverMetaData, payload: T): Observable<U> {
     EmitterAction.type = metadata.type;
 
     if (is.undefined(payload) && metadata.payload !== undefined) {
@@ -59,7 +59,7 @@ export class EmitStore extends Store {
    * @param payloads - Array with data to dispatch
    * @returns - An observable that emits events after dispatch
    */
-  private dispatchMany<T, U>(metadata: ReceiverMetaData, payloads?: T[]): Observable<U> {
+  private dispatchMany<T, U>(metadata: ReceiverMetaData, payloads: T[]): Observable<U> {
     if (!is.array(payloads)) {
       return this.dispatch([]);
     }

--- a/emitter/src/lib/core/services/emitter.service.ts
+++ b/emitter/src/lib/core/services/emitter.service.ts
@@ -7,7 +7,7 @@ import { Emittable } from '../internal/internals';
 export class EmitterService {
   constructor(private emitStore: EmitStore) {}
 
-  public action<T = any, U = any>(receiver: Function): Emittable<T, U> {
+  public action<T = void, U = any>(receiver: Function): Emittable<T, U> {
     return this.emitStore.emitter(receiver);
   }
 }

--- a/emitter/src/tests/action.spec.ts
+++ b/emitter/src/tests/action.spec.ts
@@ -57,7 +57,7 @@ describe('Actions', () => {
     public multiplyBy2?: Emittable<void | number>;
 
     @Emitter(CounterState.throwError)
-    public throwError?: Emittable<void>;
+    public throwError?: Emittable;
   }
 
   it('ofEmittable operators should return factories', () => {
@@ -155,7 +155,7 @@ describe('Actions', () => {
 
     actions$
       .pipe(ofEmittableErrored(CounterState.throwError))
-      .subscribe(({ payload, error }: OfEmittableActionContext<void>) => {
+      .subscribe(({ payload, error }: OfEmittableActionContext) => {
         expect(payload).toBe(undefined);
         expect(error!.message).toBe('Whoops!');
       });
@@ -185,7 +185,7 @@ describe('Actions', () => {
           expect(types).toContain('CounterState.decrement');
         })
       )
-      .subscribe(({ type }: OfEmittableActionContext<void>) => {
+      .subscribe(({ type }: OfEmittableActionContext) => {
         types.push(type);
       });
 
@@ -216,7 +216,7 @@ describe('Actions', () => {
           });
         })
       )
-      .subscribe(({ type }: OfEmittableActionContext<void>) => {
+      .subscribe(({ type }: OfEmittableActionContext) => {
         types.push(type);
       });
 

--- a/emitter/src/tests/emit.plugin.spec.ts
+++ b/emitter/src/tests/emit.plugin.spec.ts
@@ -84,7 +84,7 @@ describe(NgxsEmitPluginModule.name, () => {
       @State({ name: 'bar' })
       class BarState {
         @Emitter(BarState.foo)
-        private foo!: Emittable<void>;
+        private foo!: Emittable;
 
         @Receiver({ type: '@@[bar]' })
         public static foo() {}
@@ -102,7 +102,7 @@ describe(NgxsEmitPluginModule.name, () => {
     class TodosState {
       @Receiver({ type: '@@[Todos] Add todo' })
       public static addTodo({ setState, getState }: StateContext<Todo[]>, action: EmitterAction<Todo>) {
-        setState([...getState(), action.payload!]);
+        setState([...getState(), action.payload]);
       }
     }
 
@@ -137,7 +137,7 @@ describe(NgxsEmitPluginModule.name, () => {
     class TodosState {
       @Receiver()
       public static addTodo({ setState, getState }: StateContext<Todo[]>, action: EmitterAction<Todo>) {
-        setState([...getState(), action.payload!]);
+        setState([...getState(), action.payload]);
       }
     }
 
@@ -184,7 +184,7 @@ describe(NgxsEmitPluginModule.name, () => {
     @Component({ template: '' })
     class MockComponent {
       @Emitter(CounterState.increment)
-      public increment!: Emittable<void>;
+      public increment!: Emittable;
     }
 
     TestBed.configureTestingModule({
@@ -228,7 +228,7 @@ describe(NgxsEmitPluginModule.name, () => {
     @Component({ template: '' })
     class MockComponent {
       @Emitter(Bar2State.foo2)
-      public foo2!: Emittable<void>;
+      public foo2!: Emittable;
     }
 
     TestBed.configureTestingModule({
@@ -359,10 +359,10 @@ describe(NgxsEmitPluginModule.name, () => {
     @Component({ template: '' })
     class MockComponent {
       @Emitter(TodosState.setTodosSync)
-      public setTodosSync!: Emittable<Todo[]>;
+      public setTodosSync!: Emittable;
 
       @Emitter(TodosState.setTodos)
-      public setTodos!: Emittable<Todo[]>;
+      public setTodos!: Emittable;
     }
 
     TestBed.configureTestingModule({
@@ -397,7 +397,7 @@ describe(NgxsEmitPluginModule.name, () => {
     @Component({ template: '' })
     class MockComponent {
       @Emitter(TodosState.addTodo)
-      public addTodo!: Emittable<void>;
+      public addTodo!: Emittable;
     }
 
     TestBed.configureTestingModule({
@@ -464,14 +464,14 @@ describe(NgxsEmitPluginModule.name, () => {
     class TodosState {
       @Receiver({ payload: [] })
       public static setInitialTodos({ setState }: StateContext<Todo[]>, { payload }: EmitterAction<Todo[]>) {
-        setState(payload!);
+        setState(payload);
       }
     }
 
     @Component({ template: '' })
     class MockComponent {
       @Emitter(TodosState.setInitialTodos)
-      public addTodoAction!: Emittable<void>;
+      public addTodoAction!: Emittable;
     }
 
     TestBed.configureTestingModule({
@@ -496,7 +496,7 @@ describe(NgxsEmitPluginModule.name, () => {
     class AnimalsState {
       @Receiver()
       public static addAnimal({ getState, setState }: StateContext<string[]>, { payload }: EmitterAction<string>) {
-        setState([...getState(), payload!]);
+        setState([...getState(), payload]);
       }
     }
 
@@ -552,7 +552,7 @@ describe(NgxsEmitPluginModule.name, () => {
     @Component({ template: '' })
     class MockComponent {
       @Emitter(CounterState.mutate)
-      public mutate!: Emittable<void>;
+      public mutate!: Emittable;
     }
 
     TestBed.configureTestingModule({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
#102 

## What is the new behavior?
The type provided to `Emittable` or `EmitterAction` is now plainly used to type the payload, dropping optionality modifier usage.
The change requires developers to explicitly type these generics, because not doing so will result into a `void` payload parameter type (default T type changed in all interested interfaces from `any` to `void`).

This change already highlighted a type mismatch in your tests (an `Emittable<void>` incorrectly types as `Emittable<Todo[]>`) which could not be automatically detected by current implementation.

This removes the need for 'not-null-assertions' when accessing the payload into Receivers and allows to gain a fine graned typed payload.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

This actually make less verbose the common scenario where no payload is required (you can use `Emittable` instead of `Emittable<void>`), while creating a breaking change only when developer relied on the default `any` typing, which was a pretty unlikely scenario (most times you would type the payload or won't need it at all).

All untyped instances of `Emittable` should now be explicitly typed as `Emittable<any>`.

## Other information
No tests has been added or removed, being it a feature related only to compile-time behaviour.