### PR TITLE
fix: change action type to instance property (#128)

### DIFF
--- a/emitter/src/lib/core/actions/actions.ts
+++ b/emitter/src/lib/core/actions/actions.ts
@@ -3,14 +3,10 @@
  */
 export class EmitterAction<T = void> {
   /**
-   * Action type
-   */
-  public static type: string | null = null;
-
-  /**
    * Creates EmitterAction instance
    *
    * @param payload - Data to dispatch
+   * @param type - Action type
    */
-  constructor(public payload: T) {}
+  constructor(public payload: T, public type: string | null = null) {}
 }

--- a/emitter/src/lib/core/services/emit-store.service.ts
+++ b/emitter/src/lib/core/services/emit-store.service.ts
@@ -38,8 +38,6 @@ export class EmitStore extends Store {
    * @returns - An observable that emits events after dispatch
    */
   private dispatchSingle<T, U>(metadata: ReceiverMetaData, payload: T): Observable<U> {
-    EmitterAction.type = metadata.type;
-
     if (is.undefined(payload) && metadata.payload !== undefined) {
       payload = metadata.payload;
     }
@@ -51,7 +49,7 @@ export class EmitStore extends Store {
       return this.dispatch(constructEventsForSingleDispatching<T>(flattenedConstructors, payload));
     }
 
-    return this.dispatch(new EmitterAction(payload));
+    return this.dispatch(new EmitterAction(payload, metadata.type));
   }
 
   /**
@@ -64,8 +62,6 @@ export class EmitStore extends Store {
       return this.dispatch([]);
     }
 
-    EmitterAction.type = metadata.type;
-
     const { action } = metadata;
 
     if (action) {
@@ -73,6 +69,6 @@ export class EmitStore extends Store {
       return this.dispatch(constructEventsForManyDispatching(flattenedConstructors, payloads));
     }
 
-    return this.dispatch(payloads.map((payload) => new EmitterAction(payload)));
+    return this.dispatch(payloads.map((payload) => new EmitterAction(payload, metadata.type)));
   }
 }


### PR DESCRIPTION
Define a static action type property can cause action type overriding when dispatching multiple actions at the same time. It needs to be changed to instance property to avoid the issue.

Fix #128

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #128 

## What is the new behavior?

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
