### PR TITLE
fix(build): Remove ngcc as it is not needed after angular 17

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,4 @@
-afterInstall: yarn ngcc && node ./decorate-angular-cli.js && yarn husky install
+afterInstall: node ./decorate-angular-cli.js && yarn husky install
 
 nodeLinker: node-modules
 

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,4 @@
-afterInstall: node ./decorate-angular-cli.js && yarn husky install
+afterInstall: yarn husky install
 
 nodeLinker: node-modules
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Remove ngcc because it is not needed anymore
[See issue here](https://github.com/ngxs-labs/emitter/issues/788)


## What is the new behavior?
Removed ngcc

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
